### PR TITLE
Fix threshold definition in qc gross value (#420)

### DIFF
--- a/metobs_toolkit/qc_checks.py
+++ b/metobs_toolkit/qc_checks.py
@@ -213,8 +213,8 @@ def gross_value_check(obsdf, obstype, checks_settings):
 
     # find outlier observations as a list of tuples [(name, datetime), (name, datetime)]
     outl_obs = input_series.loc[
-        (input_series <= specific_settings["min_value"])
-        | (input_series >= specific_settings["max_value"])
+        (input_series < specific_settings["min_value"])
+        | (input_series > specific_settings["max_value"])
     ].index.to_list()
 
     # make new obsdf and outlierdf


### PR DESCRIPTION
This PR fixes issue #420. Fix threshold issue to only reject values strictly outside the range. I have only removed the two '=' signs as stated. This is my first time contributing so please let me know if you have any suggestions. Thank you.