### PR TITLE
Fix buddy check bug

### DIFF
--- a/src/metobs_toolkit/dataset.py
+++ b/src/metobs_toolkit/dataset.py
@@ -2025,7 +2025,7 @@ class Dataset:
         )
 
         # Handle duplicates
-        # Note: duplicates can occure when a specific record was part of more then one
+        # Note: duplicates can occur when a specific record was part of more than one
         # outlier group, and is flagged by more than one group. If so, keep the
         # first row, but concat the detail_msg's (since they describe the outlier group)
 
@@ -2240,7 +2240,7 @@ class Dataset:
         )
 
         # Handle duplicates
-        # Note: duplicates can occure when a specific record was part of more then one
+        # Note: duplicates can occur when a specific record was part of more than one
         # outlier group, and is flagged by more than one group. If so, keep the
         # first row, but concat the detail_msg's (since they describe the outlier group)
 

--- a/src/metobs_toolkit/dataset.py
+++ b/src/metobs_toolkit/dataset.py
@@ -2020,7 +2020,20 @@ class Dataset:
         # timestamps to the original timestamps
 
         # convert to a dataframe
-        df = pd.DataFrame(data=outlierslist, columns=["name", "datetime", "detail_msg"])
+        alloutliersdf = pd.DataFrame(data=outlierslist, columns=["name", "datetime", "detail_msg"])
+
+        # Handle duplicates 
+        # Note: duplicates can occure when a specific record was part of more then one
+        # outlier group, and is flagged by more than one group. If so, keep the 
+        # first row, but concat the detail_msg's (since they describe the outlier group)
+        
+        if not alloutliersdf.empty:
+            # Group by name and datetime, concatenate detail_msg for duplicates
+            alloutliersdf = (
+                alloutliersdf.groupby(['name', 'datetime'], as_index=False)
+                .agg({'detail_msg': lambda x: ' | '.join(x)})
+                .reset_index(drop=True)
+            )
 
         # update all the sensordata
         for station in target_stations:
@@ -2028,7 +2041,7 @@ class Dataset:
             sensorddata = station.get_sensor(target_obstype)
 
             # get outlier datetimeindex
-            outldt = pd.DatetimeIndex(df[df["name"] == station.name]["datetime"])
+            outldt = pd.DatetimeIndex(alloutliersdf[alloutliersdf["name"] == station.name]["datetime"])
 
             if not outldt.empty:
                 # convert to original timestamps
@@ -2041,7 +2054,7 @@ class Dataset:
                 outliertimestamps=outldt,
                 check_kwargs=qc_kwargs,
                 extra_columns={
-                    "detail_msg": df[df["name"] == station.name][
+                    "detail_msg": alloutliersdf[alloutliersdf["name"] == station.name][
                         "detail_msg"
                     ].to_numpy()
                 },
@@ -2218,7 +2231,20 @@ class Dataset:
         # timestamps to the original timestamps
 
         # convert to a dataframe
-        df = pd.DataFrame(data=outlierslist, columns=["name", "datetime", "detail_msg"])
+        alloutliersdf = pd.DataFrame(data=outlierslist, columns=["name", "datetime", "detail_msg"])
+
+        # Handle duplicates 
+        # Note: duplicates can occure when a specific record was part of more then one
+        # outlier group, and is flagged by more than one group. If so, keep the 
+        # first row, but concat the detail_msg's (since they describe the outlier group)
+        
+        if not alloutliersdf.empty:
+            # Group by name and datetime, concatenate detail_msg for duplicates
+            alloutliersdf = (
+                alloutliersdf.groupby(['name', 'datetime'], as_index=False)
+                .agg({'detail_msg': lambda x: ' | '.join(x)})
+                .reset_index(drop=True)
+            )
 
         # update all the sensordata
         for station in target_stations:
@@ -2226,7 +2252,7 @@ class Dataset:
             sensorddata = station.get_sensor(target_obstype)
 
             # get outlier datetimeindex
-            outldt = pd.DatetimeIndex(df[df["name"] == station.name]["datetime"])
+            outldt = pd.DatetimeIndex(alloutliersdf[alloutliersdf["name"] == station.name]["datetime"])
 
             if not outldt.empty:
                 # convert to original timestamps
@@ -2239,7 +2265,7 @@ class Dataset:
                 outliertimestamps=outldt,
                 check_kwargs=qc_kwargs,
                 extra_columns={
-                    "detail_msg": df[df["name"] == station.name][
+                    "detail_msg": alloutliersdf[alloutliersdf["name"] == station.name][
                         "detail_msg"
                     ].to_numpy()
                 },

--- a/src/metobs_toolkit/dataset.py
+++ b/src/metobs_toolkit/dataset.py
@@ -2020,18 +2020,20 @@ class Dataset:
         # timestamps to the original timestamps
 
         # convert to a dataframe
-        alloutliersdf = pd.DataFrame(data=outlierslist, columns=["name", "datetime", "detail_msg"])
+        alloutliersdf = pd.DataFrame(
+            data=outlierslist, columns=["name", "datetime", "detail_msg"]
+        )
 
-        # Handle duplicates 
+        # Handle duplicates
         # Note: duplicates can occure when a specific record was part of more then one
-        # outlier group, and is flagged by more than one group. If so, keep the 
+        # outlier group, and is flagged by more than one group. If so, keep the
         # first row, but concat the detail_msg's (since they describe the outlier group)
-        
+
         if not alloutliersdf.empty:
             # Group by name and datetime, concatenate detail_msg for duplicates
             alloutliersdf = (
-                alloutliersdf.groupby(['name', 'datetime'], as_index=False)
-                .agg({'detail_msg': lambda x: ' | '.join(x)})
+                alloutliersdf.groupby(["name", "datetime"], as_index=False)
+                .agg({"detail_msg": lambda x: " | ".join(x)})
                 .reset_index(drop=True)
             )
 
@@ -2041,7 +2043,9 @@ class Dataset:
             sensorddata = station.get_sensor(target_obstype)
 
             # get outlier datetimeindex
-            outldt = pd.DatetimeIndex(alloutliersdf[alloutliersdf["name"] == station.name]["datetime"])
+            outldt = pd.DatetimeIndex(
+                alloutliersdf[alloutliersdf["name"] == station.name]["datetime"]
+            )
 
             if not outldt.empty:
                 # convert to original timestamps
@@ -2231,18 +2235,20 @@ class Dataset:
         # timestamps to the original timestamps
 
         # convert to a dataframe
-        alloutliersdf = pd.DataFrame(data=outlierslist, columns=["name", "datetime", "detail_msg"])
+        alloutliersdf = pd.DataFrame(
+            data=outlierslist, columns=["name", "datetime", "detail_msg"]
+        )
 
-        # Handle duplicates 
+        # Handle duplicates
         # Note: duplicates can occure when a specific record was part of more then one
-        # outlier group, and is flagged by more than one group. If so, keep the 
+        # outlier group, and is flagged by more than one group. If so, keep the
         # first row, but concat the detail_msg's (since they describe the outlier group)
-        
+
         if not alloutliersdf.empty:
             # Group by name and datetime, concatenate detail_msg for duplicates
             alloutliersdf = (
-                alloutliersdf.groupby(['name', 'datetime'], as_index=False)
-                .agg({'detail_msg': lambda x: ' | '.join(x)})
+                alloutliersdf.groupby(["name", "datetime"], as_index=False)
+                .agg({"detail_msg": lambda x: " | ".join(x)})
                 .reset_index(drop=True)
             )
 
@@ -2252,7 +2258,9 @@ class Dataset:
             sensorddata = station.get_sensor(target_obstype)
 
             # get outlier datetimeindex
-            outldt = pd.DatetimeIndex(alloutliersdf[alloutliersdf["name"] == station.name]["datetime"])
+            outldt = pd.DatetimeIndex(
+                alloutliersdf[alloutliersdf["name"] == station.name]["datetime"]
+            )
 
             if not outldt.empty:
                 # convert to original timestamps

--- a/src/metobs_toolkit/qc_collection/buddy_check.py
+++ b/src/metobs_toolkit/qc_collection/buddy_check.py
@@ -606,10 +606,10 @@ value for 'altitude'"
 
         # Add reference to the iteration in the msg of the outliers
         outliers = [
-            (station, timestamp, f'{msg} (iteration {i}/{N_iter})')
+            (station, timestamp, f"{msg} (iteration {i}/{N_iter})")
             for station, timestamp, msg in outliers
-            ]
-           
+        ]
+
         outliersbin.extend(outliers)
         i += 1
 

--- a/src/metobs_toolkit/qc_collection/buddy_check.py
+++ b/src/metobs_toolkit/qc_collection/buddy_check.py
@@ -601,7 +601,7 @@ value for 'altitude'"
                 min_std=min_std,
             )
             # NOTE: The records that were saved by the safety net, will be tested
-            # again in the following iteration. (A different result can occure
+            # again in the following iteration. (A different result can occur
             # if the spatial-/savetynet-sample is changed in the next iteration.
 
         # Add reference to the iteration in the msg of the outliers

--- a/src/metobs_toolkit/qc_collection/buddy_check.py
+++ b/src/metobs_toolkit/qc_collection/buddy_check.py
@@ -604,6 +604,12 @@ value for 'altitude'"
             # again in the following iteration. (A different result can occure
             # if the spatial-/savetynet-sample is changed in the next iteration.
 
+        # Add reference to the iteration in the msg of the outliers
+        outliers = [
+            (station, timestamp, f'{msg} (iteration {i}/{N_iter})')
+            for station, timestamp, msg in outliers
+            ]
+           
         outliersbin.extend(outliers)
         i += 1
 

--- a/src/metobs_toolkit/sensordata.py
+++ b/src/metobs_toolkit/sensordata.py
@@ -133,7 +133,7 @@ class SensorData:
             )
 
         # NOTE! combining outliers and gaps is NOT TRIVIAL !! Frequency is not guaranteed equal
-        # and a additional gap (inbetween) can occure. Outliers and Gaps are recomputed !!!
+        # and a additional gap (inbetween) can occur. Outliers and Gaps are recomputed !!!
 
         # Think of what will happen if you merge two sensordata series, where
         # The first is QC'ed and at a hourly resolution. The second overlaps the
@@ -159,7 +159,7 @@ class SensorData:
         combined_series = selfrecords.combine_first(otherrecords)
 
         # NOTE! combining outliers and gaps is NOT TRIVIAL !! Frequency is not guaranteed equal
-        # and a additional gap (inbetween) can occure. Outliers and Gaps are recomputed !!!
+        # and a additional gap (inbetween) can occur. Outliers and Gaps are recomputed !!!
 
         # Think of what will happen if you merge two sensordata series, where
         # The first is QC'ed and at a hourly resolution. The second overlaps the

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -491,7 +491,7 @@ class TestDemoDataset:
         assert_equality(outliersdf_1_iter, solutionobj_1iter)
         assert_equality(outliersdf_2_iter, solutionobj_2iter)
 
-        # Tricky thing is that with big radii, a station can appear in mulitple
+        # Tricky thing is that with big radii, a station can appear in multiple
         # buddy groups, which can lead to edge cases. Here we test that the code
         # runs without errors
 

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -388,6 +388,31 @@ class TestDemoDataset:
 
         assert_equality(outliersdf_2_iter, solutionobj_2iter)  # dataset comparison
 
+
+    def test_buddy_check_with_big_radius(self):
+        # 0. Get info of the current check
+        _method_name = sys._getframe().f_code.co_name
+
+        #  1. get_startpoint data
+        dataset = TestDemoDataset.solutionfixer.get_solution(
+            **TestDemoDataset.solkwargs, methodname="test_import_data"
+        )
+
+        # Tricky thing is that with big radii, a station can appear in mulitple
+        # buddy groups, which can lead to edge cases. Here we test that the code
+        # runs without errors
+            
+        dataset.buddy_check(
+            target_obstype="temp",
+            spatial_buddy_radius=50000,  # Large radius
+            min_sample_size=2,
+            spatial_z_threshold=1.8,  # Lower threshold
+            N_iter=1,  # Multiple iterations increases chance of edge cases
+            instantaneous_tolerance=pd.Timedelta("5min"),
+            use_mp=False,  # Deterministic behavior
+        )
+    
+
     def test_buddy_check_with_LCZ_safety_net(self, overwrite_solution=False):
         # 0. Get info of the current check
         _method_name = sys._getframe().f_code.co_name
@@ -467,6 +492,21 @@ class TestDemoDataset:
         # validate expression
         assert_equality(outliersdf_1_iter, solutionobj_1iter)
         assert_equality(outliersdf_2_iter, solutionobj_2iter)
+        
+        
+        # Tricky thing is that with big radii, a station can appear in mulitple
+        # buddy groups, which can lead to edge cases. Here we test that the code
+        # runs without errors
+            
+        dataset.buddy_check_with_LCZ_safety_net(
+            target_obstype="temp",
+            spatial_buddy_radius=50000,  # Large radius
+            min_sample_size=2,
+            spatial_z_threshold=1.8,  # Lower threshold
+            N_iter=1,  # Multiple iterations increases chance of edge cases
+            instantaneous_tolerance=pd.Timedelta("5min"),
+            use_mp=False,  # Deterministic behavior
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -388,7 +388,6 @@ class TestDemoDataset:
 
         assert_equality(outliersdf_2_iter, solutionobj_2iter)  # dataset comparison
 
-
     def test_buddy_check_with_big_radius(self):
         # 0. Get info of the current check
         _method_name = sys._getframe().f_code.co_name
@@ -401,7 +400,7 @@ class TestDemoDataset:
         # Tricky thing is that with big radii, a station can appear in mulitple
         # buddy groups, which can lead to edge cases. Here we test that the code
         # runs without errors
-            
+
         dataset.buddy_check(
             target_obstype="temp",
             spatial_buddy_radius=50000,  # Large radius
@@ -411,7 +410,6 @@ class TestDemoDataset:
             instantaneous_tolerance=pd.Timedelta("5min"),
             use_mp=False,  # Deterministic behavior
         )
-    
 
     def test_buddy_check_with_LCZ_safety_net(self, overwrite_solution=False):
         # 0. Get info of the current check
@@ -492,12 +490,11 @@ class TestDemoDataset:
         # validate expression
         assert_equality(outliersdf_1_iter, solutionobj_1iter)
         assert_equality(outliersdf_2_iter, solutionobj_2iter)
-        
-        
+
         # Tricky thing is that with big radii, a station can appear in mulitple
         # buddy groups, which can lead to edge cases. Here we test that the code
         # runs without errors
-            
+
         dataset.buddy_check_with_LCZ_safety_net(
             target_obstype="temp",
             spatial_buddy_radius=50000,  # Large radius

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -397,7 +397,7 @@ class TestDemoDataset:
             **TestDemoDataset.solkwargs, methodname="test_import_data"
         )
 
-        # Tricky thing is that with big radii, a station can appear in mulitple
+        # Tricky thing is that with big radii, a station can appear in multiple
         # buddy groups, which can lead to edge cases. Here we test that the code
         # runs without errors
 


### PR DESCRIPTION
Solves #581 

This pull request improves the handling of duplicate outlier records in the buddy check quality control routines and enhances test coverage for edge cases. The main changes include deduplication and aggregation of outlier messages, annotation of outlier messages with iteration info, and new tests to ensure robustness when stations appear in multiple buddy groups.

**Buddy check logic improvements:**

* Outlier records in both `buddy_check` and `buddy_check_with_LCZ_safety_net` are now deduplicated by station name and timestamp, with their `detail_msg` fields concatenated to preserve all relevant outlier group information. This prevents loss of information when a record is flagged by multiple groups. [[1]](diffhunk://#diff-d65c7a5973840ae2e56e36732fb2d55df04a09b9f65a910d39348bf16081dbd6L2023-R2044) [[2]](diffhunk://#diff-d65c7a5973840ae2e56e36732fb2d55df04a09b9f65a910d39348bf16081dbd6L2221-R2255)
* When updating sensor data, the code now uses the deduplicated dataframe to ensure each outlier is only processed once per station and timestamp. [[1]](diffhunk://#diff-d65c7a5973840ae2e56e36732fb2d55df04a09b9f65a910d39348bf16081dbd6L2044-R2057) [[2]](diffhunk://#diff-d65c7a5973840ae2e56e36732fb2d55df04a09b9f65a910d39348bf16081dbd6L2242-R2268)

**Outlier message annotation:**

* Outlier messages produced by `toolkit_buddy_check` are now annotated with the iteration number, making it easier to trace which iteration flagged each outlier.

**Test coverage enhancements:**

* Added a new test, `test_buddy_check_with_big_radius`, to verify that the buddy check runs without errors when a large spatial radius causes stations to appear in multiple buddy groups, addressing potential edge cases in deduplication logic.
* Added a similar test for `buddy_check_with_LCZ_safety_net` to ensure robustness under the same edge case conditions.